### PR TITLE
fix SlotPreserveCount method

### DIFF
--- a/CSharp/Shared/ItemBox.cs
+++ b/CSharp/Shared/ItemBox.cs
@@ -295,9 +295,9 @@ namespace BaroMod_sjx
 			IsActive = false;
 		}
 
-		public static int SlotPreserveCount(ItemPrefab prefab, ItemContainer container, int slot_index)
+		public static int SlotPreserveCount(ItemPrefab prefab, Inventory inventory, ItemContainer container, int slot_index)
 		{
-			int resolved_stack_size = Math.Min(Math.Min(prefab.MaxStackSize, container.GetMaxStackSize(slot_index)), Inventory.MaxPossibleStackSize);
+			int resolved_stack_size = Math.Min(Math.Min(prefab.GetMaxStackSize(inventory), container.GetMaxStackSize(slot_index)), Inventory.MaxPossibleStackSize);
 			if (resolved_stack_size <= 1)
 			{
 				return 1;
@@ -353,7 +353,7 @@ namespace BaroMod_sjx
 				if (!IsFull)
 				{
 					//bool edited = false;	
-					int preserve = SlotPreserveCount(target_slot.Items.First().Prefab, container, slotIndex);
+					int preserve = SlotPreserveCount(target_slot.Items.First().Prefab, itemInventory, container, slotIndex);
 					var it = target_slot.Items.ToArray().AsEnumerable().GetEnumerator();
 					while (it.MoveNext() && !IsFull)
 					{
@@ -388,7 +388,7 @@ namespace BaroMod_sjx
 				target_slot = slots[slotIndex];
 			}
 
-			int preserve = SlotPreserveCount(item_type!, itemContainer, slotIndex);
+			int preserve = SlotPreserveCount(item_type!, itemInventory, itemContainer, slotIndex);
 			int spawn_count = preserve - target_slot.Items.Count;
 			int can_spawn = Math.Min(spawn_count, currentItemCount);
 


### PR DESCRIPTION
![image](https://github.com/shangjiaxuan/Barotrauma-Item-IO-Framework-Mod/assets/58655453/d2686000-0cdf-4430-bba9-144e19d66c5d)
SlotPreserveCount方法中prefab.MaxStackSize改为prefab.GetMaxStackSize(inventory)方法，以适应item的不同堆叠属性。官方不久前发布的补丁中如果maxStackSizeHoldableOrWearableInventory不大于0则获取maxStackSizeCharacterInventory而不是maxStackSize。这会导致获取到的堆叠数量大于实际能放入的数量从而无法继续存入。
In the SlotPreserveCount method, the prefab.MaxStackSize method should be changed to prefab.GetMaxStackSize(inventory) to meet different stacking attributes of the item. Officials recently released patch if maxStackSizeHoldableOrWearableInventory no greater than zero, obtain maxStackSizeCharacterInventory not maxStackSize. As a result, the number of stacks obtained is greater than the actual number of stacks that can be put in, and the storage cannot continue.